### PR TITLE
fix: 브랜드 조회 API

### DIFF
--- a/src/main/java/com/example/couphoneserver/repository/CouponItemRepository.java
+++ b/src/main/java/com/example/couphoneserver/repository/CouponItemRepository.java
@@ -14,7 +14,8 @@ public interface CouponItemRepository extends JpaRepository<CouponItem, Long> {
 
     @Query("select c from CouponItem c " +
     "where c.brand.id = :bid and c.member.id = :mid " +
-    "and c.status <> 'EXPIRED'")
+    "and c.status <> 'EXPIRED' " +
+    "ORDER BY c.stampCount DESC, c.createdDate ASC")
     CouponItem findByMemberIdAndBrandIdAndStatusNotExpired(@Param("mid") Long mid, @Param("bid") Long bid);
 
     List<CouponItem> findAllByMemberIdAndBrandId(Long mid, Long bid);

--- a/src/main/java/com/example/couphoneserver/service/BrandService.java
+++ b/src/main/java/com/example/couphoneserver/service/BrandService.java
@@ -136,7 +136,6 @@ public class BrandService {
 
         for (Brand brand : brands) {
             // 쿠폰 찾기
-
             CouponItem couponItem = couponItemRepository.findByMemberIdAndBrandIdAndStatusNotExpired(memberId, brand.getId());
 
             if (couponItem == null) { // 해당 브랜드에 쿠폰이 없을 경우

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -14,9 +14,9 @@ INSERT INTO brand (brand_id, category_id, created_date, modified_date, brand_ima
 INSERT INTO brand (brand_id, category_id, created_date, modified_date, brand_image_url, name, reward_description, status) VALUES (3, 1, '2023-07-30 10:00:00', '2023-07-30 10:05:00', 'https://example.com/images/brand2.jpg', '컴포즈 커피', '아이스 아메리카노 한 잔 무료 증정', 'ACTIVE');
 
 -- 샘플 데이터 생성: store 테이블
-INSERT INTO store (store_id, latitude, longitude, brand_id, created_date, modified_date, name, status, address) VALUES (1, 37.12345, -122.67890, 1, '2023-07-31 13:00:00', '2023-07-31 13:00:00',  '메가커피 건대입구점', 'ACTIVE', '서울특별시 건대입구로 1111');
-INSERT INTO store (store_id, latitude, longitude, brand_id, created_date, modified_date, name, status, address) VALUES (2, 37.12345, -110.67890, 1, '2023-07-31 13:00:00', '2023-07-31 13:00:00', '메가커피 세종대입구점', 'ACTIVE', '서울특별시 세종대입구로 2222');
-INSERT INTO store (store_id, latitude, longitude, brand_id, created_date, modified_date, name, status, address) VALUES (3, 37.12345, -100.67890, 2, '2023-07-31 13:00:00', '2023-07-31 13:00:00', '컴포즈커피 건대입구점', 'ACTIVE', '서울특별시 건대입구로 1111');
+INSERT INTO store (store_id, latitude, longitude, brand_id, created_date, modified_date, address, name, status) VALUES (1, 37.12345, -122.67890, 1, '2023-07-31 13:00:00', '2023-07-31 13:00:00', '서울특별시 메가커피 건대입구점 건대입구로 11111', '메가커피', 'ACTIVE');
+INSERT INTO store (store_id, latitude, longitude, brand_id, created_date, modified_date, address, name, status) VALUES (2, 37.12345, -110.67890, 1, '2023-07-31 13:00:00', '2023-07-31 13:00:00', '서울특별시 메가커피 세종대입구점 세종대입구로 22222', '메가커피', 'ACTIVE');
+INSERT INTO store (store_id, latitude, longitude, brand_id, created_date, modified_date, address, name, status) VALUES (3, 37.12345, -100.67890, 2, '2023-07-31 13:00:00', '2023-07-31 13:00:00', '서울특별시 컴포즈커피 건대입구점 건대입구로 11111', '컴포즈커피', 'ACTIVE');
 
 -- 샘플 데이터 생성: coupon_item 테이블
 INSERT INTO coupon_item (coupon_item_id, stamp_count, brand_id, created_date, member_id, modified_date, status) VALUES (1, 5, 1, '2023-07-31 12:45:00', 1, '2023-07-31 12:45:00', 'INACTIVE');


### PR DESCRIPTION
- 필터링 추가 (적립 개수 많은 순 -> 생성 시간 빠른 순)
- 검색어로 브랜드 조회 시 'ACTIVE' or 'INACTIVE' 상태의 쿠폰을 반환
- 브랜드 리스트 얻는 부분 중복되어서 메서드로 분리했습니다.

S3 업로드 구현중입니다.. 잘 안 돼서.. 내일 다시 해보겠습니다..🫠